### PR TITLE
fix that multiple chunks of JSON are sent by Docker for Mac

### DIFF
--- a/lib/fpm/fry/build_output_parser.rb
+++ b/lib/fpm/fry/build_output_parser.rb
@@ -10,12 +10,17 @@ module FPM; module Fry
     end
 
     def call(chunk, *_)
-      json = JSON.parse(chunk)
-      stream = json['stream']
-      if /\ASuccessfully built (\w+)\Z/.match(stream)
-        images << $1
+      # new docker for Mac results in data like this:
+      # "{'stream':' ---\\u003e 3bc51d6a4c46\\n'}\r\n{'stream':'Step 2 : WORKDIR /tmp/build\\n'}\r\n"
+      # this isn't valid JSON, of course, so we process each part individually
+      chunk.split("\r\n").each do |sub_chunk|
+        json = JSON.parse(sub_chunk)
+        stream = json['stream']
+        if /\ASuccessfully built (\w+)\Z/.match(stream)
+          images << $1
+        end
+        out << stream
       end
-      out << stream
     end
 
   end


### PR DESCRIPTION
turns out that adding the json didn't really solve this problem.
