### PR TITLE
Allow to set temp directory for downloads

### DIFF
--- a/lib/fpm/fry/command.rb
+++ b/lib/fpm/fry/command.rb
@@ -13,6 +13,9 @@ module FPM; module Fry
     option '--debug', :flag, 'Turns on debugging'
     option '--[no-]tls', :flag, 'Turns on tls ( default is false for schema unix, tcp and http and true for https )'
     option '--[no-]tlsverify', :flag, 'Turns off tls peer verification', default:true, environment_variable: 'DOCKER_TLS_VERIFY'
+    option ["-t", "--tmpdir"], "PATH", 'Write tmp data to PATH', default: '/tmp/fpm-fry', attribute_name: :dir do |s|
+      String(s)
+    end
 
     subcommand 'fpm', 'Works like fpm but with docker support', FPM::Command
 
@@ -22,7 +25,7 @@ module FPM; module Fry
 
     def initialize(invocation_path, ctx = {}, parent_attribute_values = {})
       super
-      @ui = ctx.fetch(:ui){ UI.new }
+      @ui = ctx.fetch(:ui){ UI.new(tmpdir: dir) }
       @client = ctx[:client]
     end
 

--- a/lib/fpm/fry/ui.rb
+++ b/lib/fpm/fry/ui.rb
@@ -3,7 +3,7 @@ require 'fpm/fry/channel'
 module FPM; module Fry
   class UI < Struct.new(:out, :err, :logger, :tmpdir)
 
-    def initialize( out = STDOUT, err = STDERR, logger = nil , tmpdir = '/tmp/fpm-fry' )
+    def initialize( out: STDOUT, err: STDERR, logger: nil , tmpdir: '/tmp/fpm-fry' )
       logger ||= Channel.new.tap{|chan| chan.subscribe(Cabin::NiceOutput.new(out)) }
       FileUtils.mkdir_p( tmpdir )
       super( out, err, logger, tmpdir )

--- a/spec/command/cook_spec.rb
+++ b/spec/command/cook_spec.rb
@@ -12,7 +12,7 @@ describe FPM::Fry::Command::Cook do
   end
 
   let(:ui) do
-    FPM::Fry::UI.new(StringIO.new,StringIO.new,nil,tmpdir)
+    FPM::Fry::UI.new(out: StringIO.new, err: StringIO.new, logger: nil, tmpdir: tmpdir)
   end
 
   after(:each) do


### PR DESCRIPTION
This allows to set the tmp directory of the build, where for example downloads will be stored. This is needed to avoid build errors when two builds try to write the same file on the same host.