### PR TITLE
allow sha512 checksums

### DIFF
--- a/fpm-fry.gemspec
+++ b/fpm-fry.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |gem|
   gem.name    = 'fpm-fry'
-  gem.version = '0.6.0'
+  gem.version = '0.6.1'
   gem.date    = Time.now.strftime("%Y-%m-%d")
 
   gem.summary = "FPM Fry"

--- a/lib/fpm/fry/source/archive.rb
+++ b/lib/fpm/fry/source/archive.rb
@@ -21,6 +21,7 @@ module FPM; module Fry ; module Source
   #
   #   - 40 characters = sha1
   #   - 64 characters = sha256
+  #   - 128 characters = sha512
   # 
   # Let's be honest: all other checksum algorithms aren't or shouldn't be in use anyway.
   class Archive
@@ -315,6 +316,8 @@ module FPM; module Fry ; module Source
       case(checksum)
       when nil
         return Digest::SHA256
+      when /\A(sha512:)?[0-9a-f]{128}\z/ then
+        return Digest::sha512
       when /\A(sha256:)?[0-9a-f]{64}\z/ then
         return Digest::SHA256
       when /\A(sha1:)?[0-9a-f]{40}\z/ then


### PR DESCRIPTION
This allows for sha512 checksums to be used, which is a common standard in this day and age.