### PR TITLE
pass platform option to docker when pulling base image

### DIFF
--- a/lib/fpm/fry/client.rb
+++ b/lib/fpm/fry/client.rb
@@ -190,7 +190,7 @@ class FPM::Fry::Client
     raise
   end
 
-  def pull(image)
+  def pull(image, platform: nil)
     last_status = ""
     streamer = lambda do |chunk, remaining_bytes, total_bytes|
       chunk.each_line do |line|
@@ -208,7 +208,9 @@ class FPM::Fry::Client
         end
       end
     end
-    agent.post(path: url('images','create'), query: {'fromImage' => image}, :response_block => streamer)
+    query = {'fromImage' => image}
+    query['platform'] = platform if platform
+    agent.post(path: url('images','create'), query: query, :response_block => streamer)
   end
 
   def delete(image)

--- a/lib/fpm/fry/command/cook.rb
+++ b/lib/fpm/fry/command/cook.rb
@@ -209,7 +209,7 @@ module FPM; module Fry
     end
 
     def pull_base_image!
-      client.pull(image)
+      client.pull(image, platform: platform)
     rescue Excon::Error
       logger.error "could not pull base image #{image}"
       raise


### PR DESCRIPTION
Recent changes to docker broke auto pulling the base image and this change fixes the problem.