### PR TITLE
Support fpm 1.16.0

### DIFF
--- a/fpm-fry.gemspec
+++ b/fpm-fry.gemspec
@@ -27,5 +27,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir['lib/**/*'] & `git ls-files -z`.split("\0")
 
   gem.add_dependency 'excon', '~> 0.71'
-  gem.add_dependency 'fpm', '~> 1.13'
+  gem.add_dependency 'fpm', '~> 1.16'
+  gem.add_dependency 'clamp', '> 1.1.0'
 end

--- a/lib/fpm/fry/command.rb
+++ b/lib/fpm/fry/command.rb
@@ -23,7 +23,7 @@ module FPM; module Fry
     extend Forwardable
     def_delegators :ui, :out, :err, :logger, :tmpdir
 
-    def initialize(invocation_path, ctx = {}, parent_attribute_values = {})
+    def initialize(invocation_path, ctx = {})
       super
       @ui = ctx.fetch(:ui){ UI.new(tmpdir: dir) }
       @client = ctx[:client]

--- a/lib/fpm/fry/command/cook.rb
+++ b/lib/fpm/fry/command/cook.rb
@@ -24,7 +24,7 @@ module FPM; module Fry
     parameter 'image', 'Docker image to build from'
     parameter '[recipe]', 'Recipe file to cook', default: 'recipe.rb'
 
-    def initialize(invocation_path, ctx = {}, parent_attribute_values = {})
+    def initialize(invocation_path, ctx = {})
       @tls = nil
       require 'digest'
       require 'fileutils'


### PR DESCRIPTION
fpm 1.16.0 relaxed clamp dependency and clamp >= 1.1.0 removed parent_attribute_values param for Command#initialize