### PR TITLE
don’t install recommended packages when building debian packages

### DIFF
--- a/lib/fpm/fry/docker_file.rb
+++ b/lib/fpm/fry/docker_file.rb
@@ -141,7 +141,7 @@ module FPM; module Fry
               update = 'apt-get update && '
             end
             df[:dependencies] << "ARG DEBIAN_FRONTEND=noninteractive"
-            df[:dependencies] << "RUN #{update}apt-get install --yes #{Shellwords.join(build_dependencies)}"
+            df[:dependencies] << "RUN #{update}apt-get install --no-install-recommends --yes #{Shellwords.join(build_dependencies)}"
           when 'redhat'
             df[:dependencies] << "RUN yum -y install #{Shellwords.join(build_dependencies)}"
           else

--- a/spec/docker_file_spec.rb
+++ b/spec/docker_file_spec.rb
@@ -97,7 +97,7 @@ SHELL
 FROM <base>
 WORKDIR /tmp/build
 ARG DEBIAN_FRONTEND=noninteractive
-RUN apt-get install --yes arg blub foo
+RUN apt-get install --no-install-recommends --yes arg blub foo
 COPY .build.sh /tmp/build/
 CMD /tmp/build/.build.sh
 SHELL
@@ -152,7 +152,7 @@ SHELL
 FROM <base>
 WORKDIR /tmp/build
 ARG DEBIAN_FRONTEND=noninteractive
-RUN apt-get install --yes D a b e\\=1.0.0
+RUN apt-get install --no-install-recommends --yes D a b e\\=1.0.0
 COPY .build.sh /tmp/build/
 CMD /tmp/build/.build.sh
 SHELL
@@ -177,7 +177,7 @@ SHELL
 FROM <base>
 WORKDIR /tmp/build
 ARG DEBIAN_FRONTEND=noninteractive
-RUN apt-get install --yes a
+RUN apt-get install --no-install-recommends --yes a
 COPY .build.sh /tmp/build/
 CMD /tmp/build/.build.sh
 SHELL
@@ -240,7 +240,7 @@ FROM <base>
 WORKDIR /tmp/build
 probe a
 ARG DEBIAN_FRONTEND=noninteractive
-RUN apt-get install --yes a
+RUN apt-get install --no-install-recommends --yes a
 probe b
 COPY .build.sh /tmp/build/
 CMD /tmp/build/.build.sh


### PR DESCRIPTION
This helps to improve build time, especially when running under QEMU.